### PR TITLE
Add links to https://addons.opera.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # chrome-webstore-extension
-Contains the code of extension hosted at addons.opera.com which allows users to install extensions from Google Chrome Web Store directly in Opera browser
+Contains the code of [Download Chrome Extension](https://addons.opera.com/en/extensions/details/download-chrome-extension-9) hosted at https://addons.opera.com which allows users to install extensions from Google Chrome Web Store directly in Opera browser


### PR DESCRIPTION
This patch added two links to https://addons.opera.com

1. The link to the extension in Opera add-ons; and
1. Make the link to https://addons.opera.com clickable