### PR TITLE
Throw network error only when the download failed

### DIFF
--- a/api/installer.js
+++ b/api/installer.js
@@ -167,7 +167,7 @@ class Installer extends Api {
                 clearInterval(interv);
                 this.onDownloadProgress.dispatch({id, percentDownloaded: 1});
                 onUnpacked();
-              } else if (download) {
+              } else if (download && download.error) {
                 clearInterval(interv);
                 alert(chrome.i18n.getMessage('installerErrorNetwork'));
                 onError();


### PR DESCRIPTION
normally there should be no download entry as Opera should detect crx file and hide its state, but looks like sometimes it is not handled that way. This is why I changed logic to throw error only when there is download entry and the entry has an error message.